### PR TITLE
mark no @@species support for Rows/Columns classes

### DIFF
--- a/lib/columns.js
+++ b/lib/columns.js
@@ -172,4 +172,4 @@ class Column {
 /**
  * @module columns
  */
-module.exports = Columns
+module.exports = require('./no-species')(Columns)

--- a/lib/no-species.js
+++ b/lib/no-species.js
@@ -1,0 +1,17 @@
+'use strict'
+
+// Mark a constructor not supporting @@species
+function markNoSpecies(constructor) {
+  if (Symbol.species) {
+    Object.defineProperty(constructor, Symbol.species, {
+      get: function() { return undefined; },
+      configurable: true,
+    });
+  }
+  return constructor;
+}
+
+/**
+@module no-species
+*/
+module.exports = markNoSpecies

--- a/lib/rows.js
+++ b/lib/rows.js
@@ -90,4 +90,4 @@ function objectToIterable (row, columns) {
 /**
  * @module rows
  */
-module.exports = Rows
+module.exports = require('./no-species')(Rows)


### PR DESCRIPTION
Rows/Columns classes extends built-in Array but do not support ```@@species```.
They'll run into problems when ```@@species``` implementation available in node.
Fixed by declaring these classes not supporting ```@@species```.